### PR TITLE
Fix linux linking

### DIFF
--- a/cbits/helpers.c
+++ b/cbits/helpers.c
@@ -73,3 +73,6 @@ void wrapper_SDL_CompilerBarrier(void) { SDL_CompilerBarrier(); }
 void wrapper_SDL_MemoryBarrierAcquire(void) { SDL_MemoryBarrierAcquire(); }
 void wrapper_SDL_MemoryBarrierRelease(void) { SDL_MemoryBarrierRelease(); }
 void wrapper_SDL_CPUPauseInstruction(void) { SDL_CPUPauseInstruction(); }
+
+// Wrappers for macros in SDL_Assert
+void wrapper_SDL_TriggerBreakpoint(void) { SDL_TriggerBreakpoint(); }

--- a/cbits/helpers.c
+++ b/cbits/helpers.c
@@ -67,3 +67,9 @@ void* wrapper_SDL_GetWindowICCProfile(SDL_Window *window, size_t *size) {
     SDL_free(profile);
     return copy;
 }
+
+// Wrappers for macros in SDL_Atomic
+void wrapper_SDL_CompilerBarrier(void) { SDL_CompilerBarrier(); }
+void wrapper_SDL_MemoryBarrierAcquire(void) { SDL_MemoryBarrierAcquire(); }
+void wrapper_SDL_MemoryBarrierRelease(void) { SDL_MemoryBarrierRelease(); }
+void wrapper_SDL_CPUPauseInstruction(void) { SDL_CPUPauseInstruction(); }

--- a/src/SDL/Assert.hsc
+++ b/src/SDL/Assert.hsc
@@ -98,7 +98,7 @@ foreign import ccall unsafe "SDL_ResetAssertionReport"
   sdlResetAssertionReport :: IO ()
 
 -- | Attempt to tell an attached debugger to pause
-foreign import ccall unsafe "SDL_TriggerBreakpoint"
+foreign import ccall unsafe "wrapper_SDL_TriggerBreakpoint"
   sdlTriggerBreakpoint :: IO ()
 
 -- | Implementation for SDL_assert as a Haskell function

--- a/src/SDL/Atomic.hs
+++ b/src/SDL/Atomic.hs
@@ -90,7 +90,7 @@ foreign import ccall unsafe "SDL_UnlockSpinlock"
 -- Memory Barrier Functions
 
 -- | Mark a compiler barrier.
-foreign import ccall unsafe "static inline"
+foreign import ccall unsafe "wrapper_SDL_CompilerBarrier"
   sdlCompilerBarrier :: IO ()
 
 -- | Insert a memory release barrier (function version).
@@ -102,15 +102,15 @@ foreign import ccall unsafe "SDL_MemoryBarrierAcquireFunction"
   sdlMemoryBarrierAcquireFunction :: IO ()
 
 -- | Insert a memory release barrier (macro version).
-foreign import ccall unsafe "static inline"
+foreign import ccall unsafe "wrapper_SDL_MemoryBarrierRelease"
   sdlMemoryBarrierRelease :: IO ()
 
 -- | Insert a memory acquire barrier (macro version).
-foreign import ccall unsafe "static inline"
+foreign import ccall unsafe "wrapper_SDL_MemoryBarrierAcquire"
   sdlMemoryBarrierAcquire :: IO ()
 
 -- | Insert a CPU-specific "pause" instruction.
-foreign import ccall unsafe "static inline"
+foreign import ccall unsafe "wrapper_SDL_CPUPauseInstruction"
   sdlCPUPauseInstruction :: IO ()
 
 -- Atomic Integer Functions

--- a/src/SDL/Tray.hsc
+++ b/src/SDL/Tray.hsc
@@ -56,7 +56,6 @@ module SDL.Tray
   , sdlGetTrayEntryEnabled
   , sdlSetTrayEntryCallback
   , sdlClickTrayEntry
-  , sdlIsTraySupported
 
   ) where
 
@@ -105,13 +104,6 @@ pattern SDL_TRAYENTRY_CHECKED  = SDLTrayEntryFlags #{const SDL_TRAYENTRY_CHECKED
 type SDLTrayCallback = Ptr () -> SDLTrayEntry -> IO ()
 
 -- * Tray Management
-
--- | Returns True if system tray is supported on this platform.
-foreign import ccall unsafe "SDL_IsTraySupported"
-  c_sdlIsTraySupported :: IO CBool
-
-sdlIsTraySupported :: IO Bool
-sdlIsTraySupported = toBool <$> c_sdlIsTraySupported
 
 -- | Creates a new system tray icon instance.
 foreign import ccall unsafe "SDL_CreateTray"


### PR DESCRIPTION
I ran into unresolved symbols for these foreign imports while building for Linux. For some reason these didn't error when building the package itself; just when building the dear-imgui package. Also for some reason I never saw these errors at all when building for Mac or Windows. But anyway, it does seem to be the case that these symbols are missing for different reasons.

Some are macros, which mean they need wrappers (actual C functions to import).
And one was an actual function but it was removed from SDL HEAD.

Btw thanks for all your work on this package!